### PR TITLE
Feat/blog and projects and minor fixes

### DIFF
--- a/archetypes/blog.md
+++ b/archetypes/blog.md
@@ -1,0 +1,7 @@
+---
+title: "{{ replace .Name "-" " " | title }}"
+description: "Metadescription of the blogpost"
+date: {{ .Date }}
+draft: true
+---
+

--- a/archetypes/projects.md
+++ b/archetypes/projects.md
@@ -1,0 +1,6 @@
+---
+title: "{{ replace .Name "-" " " | title }}"
+description: "Metadescription of the project"
+date: {{ .Date }}
+draft: true
+---

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -75,20 +75,42 @@ body {
 }
 
 .navbar-brand {
-  font-size: 1.4rem;
-  line-height: 3.5rem;
+  font-size: 1rem;
+  line-height: 2.5rem;
   font-weight: 400;
   margin-left: 1rem;
 }
 
 .navbar-brand img {
   margin-right: 1.3rem;
-  width: 3.5rem;
-  height: 3.5rem;
+  width: 2.5rem;
+  height: 2.5rem;
 }
 
 .nav-item {
   white-space: nowrap;
+}
+
+.nav__double__container {
+  background-color: #f8f9fa;
+  position: relative;
+  z-index: 5;
+}
+
+.navbar-nav {
+  padding-left: 1rem;
+}
+
+@media (min-width: 460px) {
+  .navbar-brand {
+    font-size: 1.4rem;
+    line-height: 3.5rem;
+  }
+  
+  .navbar-brand img {
+    width: 3.5rem;
+    height: 3.5rem;
+  }
 }
 
 @media (min-width: 768px) {
@@ -98,6 +120,11 @@ body {
   
   .nav__double__container {
     padding-right: 0;
+    background-color: transparent;
+  }
+
+  .navbar-nav {
+    padding-left: 0;
   }
 
   .nav__double__collapse {
@@ -108,6 +135,7 @@ body {
     padding-left: 15px;
   }
 }
+
 @media (min-width: 992px) {
   .nav-item--main {
     padding-right: 2rem;
@@ -318,6 +346,13 @@ body {
   .homepage__hero {
     padding-top: 7.5rem;
     padding-bottom: 7.5rem;
+  }
+}
+
+@media (max-width: 460px) {
+  
+  .homepage__hero .h1 {
+    font-size: 36px;
   }
 }
 

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -123,8 +123,8 @@ body {
 * Section
 */
 .section {
-  padding-top: 3rem;
-  padding-bottom: 3rem;
+  padding-top: 6rem;
+  padding-bottom: 6rem;
   color: #86939E;
   font-weight: 400;
   font-size: 1.125rem;
@@ -166,10 +166,6 @@ body {
   background-color: #F4F4F4;
 }
 
-.section {
-  padding-top: 5rem;
-  padding-bottom: 5rem;
-}
 
 
 /**

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -352,3 +352,28 @@ body {
   font-weight: 300;
   font-style: normal;
 }
+
+
+/**
+* Page: Single / Blogpost
+*/
+
+.post {
+  max-width: 75ch;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.post h1,
+.post h2,
+.post h3,
+.post h4,
+.post h5,
+.post h6,
+.post p,
+.post ul,
+.post ol,
+.post blockquote {
+  margin-bottom: 1em;
+  line-height: 1.5;
+}

--- a/content/_index.html
+++ b/content/_index.html
@@ -17,7 +17,7 @@ draft: false
   </div>
 </div>
 
-<div class="section section--offerings" style="padding-top: 5rem; padding-bottom: 8rem;">
+<div class="section section--offerings">
   <div class="container">
     <p class="text-center">The GetCloudnative Value</p>
     <h2 class="display-4 text-center">Our Offering</h2>
@@ -47,7 +47,7 @@ draft: false
   </div>
 </div>
 
-<div class="section section-bg-secondary" style="padding-top:8rem; padding-top: 5rem;">
+<div class="section section-bg-secondary" >
   <div class="container">
     <h2 class="display-4 text-center">Let&rsquo;s Walk the Talk</h2>
     <p class="text-center mt-5 mb-5 lead">
@@ -60,7 +60,7 @@ draft: false
   </div>
 </div>
 
-<div class="section" style="padding-top: 5.5rem; padding-bottom: 5.5rem">
+<div class="section" >
   <div class="container">
     <h2 class="display-4 text-center">We Deliver Value-Driven Solutions</h2>
     <!-- TODO: fix inline style -->
@@ -90,7 +90,7 @@ draft: false
   </div>
 </div>
 
-<div class="section testimonials" style="padding-top: 5.5rem; padding-bottom: 5rem">
+<div class="section testimonials">
   <div class="container">
     <h2 class="display-4 text-center">What People Say</h2>
     <p class="text-center lead" style="margin-bottom: 4rem">

--- a/content/blog/_index.md
+++ b/content/blog/_index.md
@@ -1,0 +1,4 @@
+---
+title: "Blogposts"
+emptyText: "Unfortunately there are no posts released yet. Be sure to check back soon."
+---

--- a/content/imprint.html
+++ b/content/imprint.html
@@ -1,14 +1,9 @@
 ---
-title: "Imprint | GCn - GetCloudnative"
+title: "Imprint"
 date: 2018-08-10T18:59:17+02:00
 draft: false
+layout: "imprint"
 ---
-
-<div class="jumbotron homepage__hero">
-  <div class="container">
-    <h1 class="h1">Imprint</h1>
-  </div>
-</div>
 
 <div class="section">
   <div class="container">

--- a/content/projects/_index.md
+++ b/content/projects/_index.md
@@ -1,0 +1,4 @@
+---
+title: "Projects"
+emptyText: "Unfortunately there are no projects released yet. Be sure to check back soon."
+---

--- a/layouts/_default/imprint.html
+++ b/layouts/_default/imprint.html
@@ -1,0 +1,6 @@
+{{ define "content" }}
+  {{ partial "page-single/imprint.html" . }}
+{{ end }}
+
+{{ define "footer" }}
+{{ end }}

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,0 +1,36 @@
+{{ define "content" }}
+<div class="jumbotron homepage__hero">
+  <div class="container">
+    <h1 class="h1">{{ .Title }}</h1>
+  </div>
+</div>
+
+<main>
+  {{if .Content}}
+  <div class="section">
+    <div class="container">
+      {{.Content}}
+    </div>
+  </div>
+  {{ end }}
+
+  <div class="section">
+    <div class="container">
+
+      {{if .Pages }}
+        <ul>
+          <!-- Ranges through content/{taxonomy}/*.md -->
+          {{ range .Pages }}
+          <li>
+            <a href="{{.Permalink}}">{{.Date.Format "2006-01-02"}} | {{.Title}}</a>
+          </li>
+          {{ end }}
+        </ul>
+      {{ else }}
+      <p>{{ .Params.emptyText }}</p>
+      {{ end }}
+    </div>
+  </div>
+  
+</main>
+{{ end }}

--- a/layouts/partials/page-single/content.html
+++ b/layouts/partials/page-single/content.html
@@ -1,5 +1,22 @@
-<article>
-  <div class="post">
-    {{ .Content }}
+
+<div class="jumbotron homepage__hero">
+  <div class="container">
+    <h1 class="h1">{{ .Title }}</h1>
+  </div>
+</div>
+
+
+<article class="section">
+  <div class="container">
+    <div class="post">
+      {{ $newContent := .Content }}
+      {{ $newContent := replaceRE "<h1" "<h1 class='h1' " $newContent}}
+      {{ $newContent := replaceRE "<h2" "<h2 class='h2' " $newContent}}
+      {{ $newContent := replaceRE "<h3" "<h3 class='h3' " $newContent}}
+      {{ $newContent := replaceRE "<h4" "<h4 class='h4' " $newContent}}
+      {{ $newContent := replaceRE "<h5" "<h5 class='h5' " $newContent}}
+      {{ $newContent := replaceRE "<h6" "<h6 class='h6' " $newContent}}
+      {{ $newContent | safeHTML}}
+    </div>
   </div>
 </article>

--- a/layouts/partials/page-single/imprint.html
+++ b/layouts/partials/page-single/imprint.html
@@ -1,0 +1,7 @@
+<div class="jumbotron homepage__hero">
+  <div class="container">
+    <h1 class="h1">{{ .Title }}</h1>
+  </div>
+</div>
+
+{{ .Content }}

--- a/layouts/shortcodes/figure.html
+++ b/layouts/shortcodes/figure.html
@@ -1,0 +1,19 @@
+<!-- image -->
+<figure class="figure">
+  {{ if .Get "link"}}<a href="{{ .Get "link" }}" {{ with .Get "target" }} target="{{ . }}" {{ end }}
+    {{ with .Get "rel" }} rel="{{ . }}" {{ end }}>{{ end }}
+    <img class="figure-img img-fluid" src="{{ .Get "src" }}" {{ if or (.Get "alt") (.Get "caption") }} alt="{{ with .Get "alt"}}{{.}}{{else}}{{ .Get "caption" }}{{ end }}"
+      {{ end }} {{ with .Get "width" }} width="{{.}}" {{ end }} {{ with .Get "height" }} height="{{.}}" {{ end }} />
+    {{ if .Get "link"}}</a>{{ end }}
+  {{ if or (or (.Get "title") (.Get "caption")) (.Get "attr")}}
+  <figcaption class="figure-caption">
+    {{ if or (.Get "caption") (.Get "attr")}}<p>
+      {{ .Get "caption" }}
+      {{ with .Get "attrlink"}}<a href="{{.}}"> {{ end }}
+        {{ .Get "attr" }}
+        {{ if .Get "attrlink"}}</a> {{ end }}
+    </p> {{ end }}
+  </figcaption>
+  {{ end }}
+</figure>
+<!-- image -->


### PR DESCRIPTION
you can create new blog posts or projects with the `hugo new` command. Archetypes are set up to be used for these pages. i.e. `hugo new blog/my-first-blogpost.md` or `hugo new projects/my-first-project.md`

Styling of the hub pages is very rudimentary. I'm sure you have some idea of how these pages should look in the future. 

Tackling 
* #28 overview blog page
* #29 overview project page
* #7 Unified section spacings
